### PR TITLE
feat(trackError): Track error's stack trace on Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .pub/
 
 build/
+
+.idea
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.0.0] - 2022-10-25
+
+* BREAKING CHANGE: Changed trackError parameters from position parameters to named parameters
+* feat(trackError): Track error's stack trace on Android
+* feat: Upgraded Android target version to 33
+* feat: Upgraded dependencies
+* docs: Updated README usage section to new recommend implementation of catching errors not caught by Flutter
+
 ## [1.0.0] - 2021-11-01
 
 * AppCenter Plugin with Analytics and Crashes.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ For more details: [Get Started with iOS](https://docs.microsoft.com/en-us/appcen
 
 ## Usage
 
+Simple package usage:
+
 ```dart
 import 'package:app_center_plugin/app_center_plugin.dart';
 
@@ -33,3 +35,36 @@ AppCenter.trackEvent('my event', <String, String> {
 
 AppCenter.trackError('error message');
 ```
+
+How to catch Flutter and Dart errors:
+
+```dart
+WidgetsFlutterBinding.ensureInitialized();
+
+// Start AppCenter
+await AppCenter.start(secret);
+
+// Log Flutter errors with FlutterError.onError
+FlutterError.onError = (FlutterErrorDetails errorDetails) {
+  FlutterError.presentError(errorDetails);
+  // Send Flutter errors to AppCenter
+  AppCenter.trackError(
+    errorDetails.exceptionAsString(),
+    properties: {"library": errorDetails.library ?? ""},
+    stackTrace: errorDetails.stack,
+  );
+};
+
+// Log errors not caught by Flutter with PlatformDispatcher.instance.onError
+PlatformDispatcher.instance.onError = (error, stack) {
+  AppCenter.trackError(
+    error.toString(),
+    stackTrace: stack,
+  );
+  return true;
+};
+
+runApp(const MyApp());
+```
+
+Check out the [official documentation](https://docs.flutter.dev/testing/errors) for more information on how to handle errors in Flutter 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'dev.eronildo.app_center'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -46,8 +46,7 @@ android {
 }
 
 dependencies {
-    def appCenterSdkVersion = '4.3.1'
+    def appCenterSdkVersion = '4.4.5'
     implementation "com.microsoft.appcenter:appcenter-analytics:${appCenterSdkVersion}"
     implementation "com.microsoft.appcenter:appcenter-crashes:${appCenterSdkVersion}"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip

--- a/android/src/main/kotlin/dev/eronildo/app_center/AppCenterPlugin.kt
+++ b/android/src/main/kotlin/dev/eronildo/app_center/AppCenterPlugin.kt
@@ -8,9 +8,9 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import com.microsoft.appcenter.AppCenter;
-import com.microsoft.appcenter.analytics.Analytics;
-import com.microsoft.appcenter.crashes.Crashes;
+import com.microsoft.appcenter.AppCenter
+import com.microsoft.appcenter.analytics.Analytics
+import com.microsoft.appcenter.crashes.Crashes
 
 /** AppCenterPlugin */
 class AppCenterPlugin: FlutterPlugin, MethodCallHandler {
@@ -22,7 +22,7 @@ class AppCenterPlugin: FlutterPlugin, MethodCallHandler {
   private var application: Application? = null
 
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    application = flutterPluginBinding.getApplicationContext() as Application
+    application = flutterPluginBinding.applicationContext as Application
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "app_center")
     channel.setMethodCallHandler(this)
   }
@@ -42,7 +42,13 @@ class AppCenterPlugin: FlutterPlugin, MethodCallHandler {
       "trackError" -> {
         val errorMessage: String? = call.argument("errorMessage")
         val trackErrorProperties: Map<String, String>? = call.argument("properties")
+        val stackTrace: List<Map<String, String>>? = call.argument("stackTrace")
+        val stackTraceElements = mutableListOf<StackTraceElement>()
+        stackTrace?.forEach { element ->
+          stackTraceElements.add(StackTraceElement(element["declaringClass"], element["methodName"], element["fileName"], element["lineNumber"]?.toInt() ?: 0))
+        }
         val exception = Exception(errorMessage)
+        exception.stackTrace = stackTraceElements.toTypedArray()
         Crashes.trackError(exception, trackErrorProperties, null)
       }
       else -> {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -44,8 +44,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "dev.eronildo.app_center_example"
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion 21
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }
@@ -64,5 +64,4 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
+            android:exported="true"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,16 +1,40 @@
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:app_center_plugin/app_center_plugin.dart';
-
 
 const androidSecret = '043be909-44a3-4675-b8b3-3078cb55d379';
 const iOSSecret = '894914f3-91d8-48c0-a929-d02e8b5b2178';
 
 void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
   final secret = Platform.isAndroid ? androidSecret : iOSSecret;
+
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Start AppCenter
   await AppCenter.start(secret);
+
+  // Log Flutter errors with FlutterError.onError
+  FlutterError.onError = (FlutterErrorDetails errorDetails) {
+    FlutterError.presentError(errorDetails);
+    // Send Flutter errors to AppCenter
+    AppCenter.trackError(
+      errorDetails.exceptionAsString(),
+      properties: {"library": errorDetails.library ?? ""},
+      stackTrace: errorDetails.stack,
+    );
+  };
+
+  // Log errors not caught by Flutter with PlatformDispatcher.instance.onError
+  PlatformDispatcher.instance.onError = (error, stack) {
+    AppCenter.trackError(
+      error.toString(),
+      stackTrace: stack,
+    );
+    return true;
+  };
+
   runApp(const MyApp());
 }
 
@@ -45,8 +69,8 @@ class _MyHomePageState extends State<MyHomePage> {
   void _incrementCounter() {
     setState(() {
       _counter++;
-      AppCenter.trackEvent(
-          'Increment Counter', {'counter': _counter.toString()});
+      debugPrint("Sending event to AppCenter");
+      AppCenter.trackEvent('Increment Counter', {'counter': _counter.toString()});
     });
   }
 
@@ -70,11 +94,30 @@ class _MyHomePageState extends State<MyHomePage> {
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
+      floatingActionButton: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FloatingActionButton(
+            onPressed: _trackError,
+            tooltip: 'Error',
+            child: const Icon(Icons.bug_report),
+          ),
+          FloatingActionButton(
+            onPressed: _incrementCounter,
+            tooltip: 'Increment',
+            child: const Icon(Icons.add),
+          ),
+        ],
       ),
     );
   }
+
+  void _trackError() {
+    debugPrint("Sending error to AppCenter");
+    throw const CustomException("Custom error message");
+  }
+}
+
+class CustomException implements Exception {
+  const CustomException(String message);
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "2.0.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,28 +28,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -63,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -75,7 +68,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -87,28 +80,35 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -120,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -141,35 +141,28 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0-206.0.dev <3.0.0"
   flutter: ">=1.20.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,19 +1,11 @@
 name: app_center_example
 description: Demonstrates how to use the app_center plugin.
 
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
     sdk: flutter
@@ -26,59 +18,13 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages

--- a/lib/app_center_plugin.dart
+++ b/lib/app_center_plugin.dart
@@ -6,8 +6,7 @@ class AppCenter {
   static const MethodChannel _channel = MethodChannel('app_center');
 
   static Future<dynamic> start(String secret) {
-    return _channel
-        .invokeMethod('start', <String, dynamic>{'secret': secret});
+    return _channel.invokeMethod('start', <String, dynamic>{'secret': secret});
   }
 
   static Future trackEvent(String name, [Map<String, String>? properties]) =>
@@ -17,9 +16,56 @@ class AppCenter {
       });
 
   static Future trackError(String errorMessage,
-          [Map<String, String>? properties]) =>
+          {Map<String, String>? properties, StackTrace? stackTrace}) =>
       _channel.invokeMethod('trackError', <String, dynamic>{
         'errorMessage': errorMessage,
         'properties': properties ?? <String, String>{},
+        'stackTrace': convertStackTrace(stackTrace?.toString())
       });
+}
+
+List<Map<String, String>>? convertStackTrace(String? stackTrace) {
+  if (stackTrace == null) return null;
+
+  var list = <Map<String, String>>[];
+  var lines = stackTrace.toString().split('\n');
+  for (var lineRaw in lines) {
+    lineRaw = lineRaw.replaceAll(RegExp(' +'), ' ');
+    if (lineRaw.isEmpty) {
+      continue;
+    }
+
+    var line = lineRaw.split(' ');
+    var classAndMethod = line[1].split('.');
+    String declaringClass;
+    String methodName;
+    if (classAndMethod.length > 1) {
+      declaringClass = classAndMethod[0];
+      methodName = classAndMethod[1];
+    } else {
+      declaringClass = "";
+      methodName = classAndMethod[0];
+    }
+
+    var fileAndLineRaw = line[2];
+    fileAndLineRaw = fileAndLineRaw.replaceAll('(', '');
+    fileAndLineRaw = fileAndLineRaw.replaceAll(')', '');
+    var fileAndLine = fileAndLineRaw.split(':');
+    String fileName;
+    String lineNumber;
+    if (fileAndLineRaw.length > 3) {
+      fileName = "${fileAndLine[0]}:${fileAndLine[1]}";
+      lineNumber = fileAndLine[2];
+    } else {
+      fileName = fileAndLine[0];
+      lineNumber = fileAndLine[1];
+    }
+    list.add({
+      "declaringClass": declaringClass,
+      "methodName": methodName,
+      "fileName": fileName,
+      "lineNumber": lineNumber
+    });
+  }
+  return list;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,35 +21,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -61,7 +54,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -73,28 +66,35 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -127,35 +127,28 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0-206.0.dev <3.0.0"
   flutter: ">=1.20.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -108,7 +108,7 @@ packages:
     source: hosted
     version: "1.9.0"
   stack_trace:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: app_center_plugin
 description: A AppCenter Flutter plugin with Analytics and Crashes.
-version: 1.0.0
+version: 2.0.0
 homepage: https://github.com/Eronildo/app_center
 
 environment:
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
@@ -32,34 +32,3 @@ flutter:
         pluginClass: AppCenterPlugin
       ios:
         pluginClass: AppCenterPlugin
-
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  stack_trace: ^1.10.0
 
 dev_dependencies:
   flutter_test:

--- a/test/app_center_plugin_test.dart
+++ b/test/app_center_plugin_test.dart
@@ -35,17 +35,41 @@ void main() {
     expect(AppCenter.trackEvent('any_event'), completes);
   });
 
-  test('Convert stack trace', () {
-    try {
-      throw Exception();
-    } catch (e) {
+  group('Given stack trace ', () {
+    test('Should convert when stack trace is mocked', () {
       final linesOfStackTrace = convertStackTrace(stackTrace);
 
       expect(linesOfStackTrace![0]["declaringClass"], "_MyHomePageState");
       expect(linesOfStackTrace[0]["methodName"], "_trackError");
       expect(linesOfStackTrace[0]["fileName"], "package:app_center_example/main.dart");
       expect(linesOfStackTrace[0]["lineNumber"], "110");
-    }
+    });
+
+    test('Should convert when exception is throw', () {
+      try {
+        throw Exception();
+      } catch (e, s) {
+        final linesOfStackTrace = convertStackTrace(s.toString()); // FIXME
+
+        expect(linesOfStackTrace, isNotNull);
+        expect(linesOfStackTrace![0]["declaringClass"], "main.<anonymous closure>");
+        expect(linesOfStackTrace[0]["methodName"], "<anonymous closure>");
+        expect(linesOfStackTrace[0]["fileName"], contains("test/app_center_plugin_test.dart"));
+        expect(linesOfStackTrace[0]["lineNumber"], "50");
+      }
+    });
+
+    test('Should convert when stack trace is empty', () {
+      final linesOfStackTrace = convertStackTrace("");
+
+      expect(linesOfStackTrace, isEmpty);
+    });
+
+    test('Should convert when stack trace is null', () {
+      final linesOfStackTrace = convertStackTrace(null);
+
+      expect(linesOfStackTrace, isNull);
+    });
   });
 }
 

--- a/test/app_center_plugin_test.dart
+++ b/test/app_center_plugin_test.dart
@@ -1,7 +1,6 @@
+import 'package:app_center_plugin/app_center_plugin.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:app_center_plugin/app_center_plugin.dart';
-
 
 void main() {
   const MethodChannel channel = MethodChannel('app_center');
@@ -35,4 +34,41 @@ void main() {
   test('AppCenter.trackEvent', () {
     expect(AppCenter.trackEvent('any_event'), completes);
   });
+
+  test('Convert stack trace', () {
+    try {
+      throw Exception();
+    } catch (e) {
+      final linesOfStackTrace = convertStackTrace(stackTrace);
+
+      expect(linesOfStackTrace![0]["declaringClass"], "_MyHomePageState");
+      expect(linesOfStackTrace[0]["methodName"], "_trackError");
+      expect(linesOfStackTrace[0]["fileName"], "package:app_center_example/main.dart");
+      expect(linesOfStackTrace[0]["lineNumber"], "110");
+    }
+  });
 }
+
+const stackTrace = """
+#0      _MyHomePageState._trackError (package:app_center_example/main.dart:110:5)
+#1      _InkResponseState._handleTap (package:flutter/src/material/ink_well.dart:989:21)
+#2      GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:198:24)
+#3      TapGestureRecognizer.handleTapUp (package:flutter/src/gestures/tap.dart:608:11)
+#4      BaseTapGestureRecognizer._checkUp (package:flutter/src/gestures/tap.dart:296:5)
+#5      BaseTapGestureRecognizer.acceptGesture (package:flutter/src/gestures/tap.dart:267:7)
+#6      GestureArenaManager.sweep (package:flutter/src/gestures/arena.dart:157:27)
+#7      GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:443:20)
+#8      GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:419:22)
+#9      RendererBinding.dispatchEvent (package:flutter/src/rendering/binding.dart:322:11)
+#10     GestureBinding._handlePointerEventImmediately (package:flutter/src/gestures/binding.dart:374:7)
+#11     GestureBinding.handlePointerEvent (package:flutter/src/gestures/binding.dart:338:5)
+#12     GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:296:7)
+#13     GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:279:7)
+#14     _rootRunUnary (dart:async/zone.dart:1444:13)
+#15     _CustomZone.runUnary (dart:async/zone.dart:1335:19)
+#16     _CustomZone.runUnaryGuarded (dart:async/zone.dart:1244:7)
+#17     _invoke1 (dart:ui/hooks.dart:169:10)
+#18     PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:293:7)
+#19     _dispatchPointerDataPacket (dart:ui/hooks.dart:88:31)
+
+""";

--- a/test/app_center_plugin_test.dart
+++ b/test/app_center_plugin_test.dart
@@ -1,6 +1,7 @@
 import 'package:app_center_plugin/app_center_plugin.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:stack_trace/stack_trace.dart';
 
 void main() {
   const MethodChannel channel = MethodChannel('app_center');
@@ -37,11 +38,11 @@ void main() {
 
   group('Given stack trace ', () {
     test('Should convert when stack trace is mocked', () {
-      final linesOfStackTrace = convertStackTrace(stackTrace);
+      final linesOfStackTrace = convertStackTrace(Trace.parse(stackTrace).original);
 
       expect(linesOfStackTrace![0]["declaringClass"], "_MyHomePageState");
       expect(linesOfStackTrace[0]["methodName"], "_trackError");
-      expect(linesOfStackTrace[0]["fileName"], "package:app_center_example/main.dart");
+      expect(linesOfStackTrace[0]["fileName"], "main.dart");
       expect(linesOfStackTrace[0]["lineNumber"], "110");
     });
 
@@ -49,20 +50,13 @@ void main() {
       try {
         throw Exception();
       } catch (e, s) {
-        final linesOfStackTrace = convertStackTrace(s.toString()); // FIXME
+        final linesOfStackTrace = convertStackTrace(s);
 
-        expect(linesOfStackTrace, isNotNull);
-        expect(linesOfStackTrace![0]["declaringClass"], "main.<anonymous closure>");
-        expect(linesOfStackTrace[0]["methodName"], "<anonymous closure>");
-        expect(linesOfStackTrace[0]["fileName"], contains("test/app_center_plugin_test.dart"));
-        expect(linesOfStackTrace[0]["lineNumber"], "50");
+        expect(linesOfStackTrace![0]["declaringClass"], "main");
+        expect(linesOfStackTrace[0]["methodName"], "<fn>.<fn>");
+        expect(linesOfStackTrace[0]["fileName"], "app_center_plugin_test.dart");
+        expect(linesOfStackTrace[0]["lineNumber"], "51");
       }
-    });
-
-    test('Should convert when stack trace is empty', () {
-      final linesOfStackTrace = convertStackTrace("");
-
-      expect(linesOfStackTrace, isEmpty);
     });
 
     test('Should convert when stack trace is null', () {


### PR DESCRIPTION
Add `stackTrace` parameter on `trackError` method and convert Flutter stack trace to Java/Kotlin stack trace

Fix issue #1 (only fix the issue for Android, not for iOS)

**BREAKING CHANGE:** Changed `trackError`'s parameters from position parameters to named parameters

Added stack_trace package as dependency
Upgraded compileSdkVersion and targetSdkVersion to 33 (Android 13)
Upgraded AppCenter Android library to 4.4.5
Upgraded Gradle to 7.4.2
Upgraded Gradle plugin to 7.1.3
Upgraded Kotlin to 1.5.31

Updated README usage section to new recommend implementation of catching errors not caught by Flutter

Fixed stack trace:
![new_stack_trace](https://user-images.githubusercontent.com/13008789/197861217-0116a663-18d5-46a1-8e8a-17e069c01513.png)
